### PR TITLE
Implement a logger for debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Generic Project Files
 build
 
+# Sandbox Log Files
+sandbox/game-log.txt
+
 # Visual Studio 2022 Files
 */*.vcxproj
 */*.vcxproj.user

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build
 
 # Sandbox Log Files
 sandbox/game-log.txt
+sandbox/test-log.txt
 
 # Visual Studio 2022 Files
 */*.vcxproj

--- a/engine/source/application.hpp
+++ b/engine/source/application.hpp
@@ -1,6 +1,8 @@
 #ifndef HPP_GRAPEENGINE_APPLICATION
 #define HPP_GRAPEENGINE_APPLICATION
 
+#include <string>
+
 #include "core.hpp"
 
 // Forward declare window class

--- a/engine/source/core.hpp
+++ b/engine/source/core.hpp
@@ -15,6 +15,4 @@ using i64 = signed long long;
 using f32 = float;
 using f64 = double;
 
-#include <string>
-
 #endif

--- a/engine/source/logger.cpp
+++ b/engine/source/logger.cpp
@@ -4,37 +4,44 @@
 #include <fstream>
 
 namespace GRAPE {
-	Logger& Logger::GetLogger() {
-		static Logger self;
-		return self;
-	}
-
-	void Logger::SetLogFile(const std::string& filepath) {
-		this->log_file = filepath;
-	}
-
-	void Logger::ClearLogFile() {
-		std::fstream file(this->log_file, std::ios::out | std::ios::trunc);
-		if (file.is_open()) {
-			file.close();
+	namespace Logger {
+		Logger& Logger::GetLogger() {
+			static Logger self;
+			return self;
 		}
-	}
 
-	void Logger::LogMessage(const std::string& message, LogLevel level) {
-		const std::string log_colours[7] = {
-			"\033[0m",		// NONE
-			"\033[97;41m",	// FATAL
-			"\033[91m",		// ERROR
-			"\033[93m",		// WARN
-			"\033[94m",		// INFO
-			"\033[92m",		// DEBUG
-			"\033[37m"		// TRACE
-		};
+		void Logger::SetLogFile(const std::string& filepath) {
+			this->log_file = filepath;
+		}
 
-		std::cout << log_colours[level] << message << "\033[0m" << std::endl;
+		void Logger::ClearLogFile() {
+			std::fstream file(this->log_file, std::ios::out | std::ios::trunc);
+			if (file.is_open()) {
+				file.close();
+			}
+		}
 
-		// We don't write logs with a level of NONE to a file.
-		if (level != LogLevel::NONE) {
+		void Logger::LogMessage(const std::string& message, LogLevel level) {
+			const std::string log_colours[6] = {
+				"\033[97;41m",	// FATAL
+				"\033[91m",		// ERROR
+				"\033[93m",		// WARN
+				"\033[94m",		// INFO
+				"\033[92m",		// DEBUG
+				"\033[37m",		// TRACE
+			};
+
+			const std::string log_prefixes[6] = {
+				"[FATAL]: ",	// FATAL
+				"[ERROR]: ",	// ERROR
+				"[WARN]: ",		// WARN
+				"[INFO]: ",		// INFO
+				"[DEBUG]: ",	// DEBUG
+				"[TRACE]: ",	// TRACE
+			};
+
+			std::cout << log_colours[level] << log_prefixes[level] << message << "\033[0m" << std::endl;
+
 			std::fstream file(this->log_file, std::ios::out | std::ios::app);
 			if (file.is_open()) {
 				file.write(message.c_str(), message.size());
@@ -42,8 +49,8 @@ namespace GRAPE {
 				file.close();
 			}
 			else {
-				this->LogMessage("Unable to write to log file.", LogLevel::NONE);
+				std::cout << "Unable to log to '" << this->log_file << "' file." << std::endl;
 			}
 		}
-	}
+	};
 };

--- a/engine/source/logger.cpp
+++ b/engine/source/logger.cpp
@@ -1,13 +1,30 @@
 #include "logger.hpp"
 
 #include <iostream>
+#include <fstream>
 
 namespace GRAPE {
 	Logger::Logger(const std::string& log_name) {
-		(log_name);
+		this->log_file = log_name;
+		
+		// Reset log file
+		std::fstream file(this->log_file, std::ios::out | std::ios::trunc);
+		if (file.is_open()) {
+			file.close();
+		}
 	}
 
 	void Logger::LogMessage(const std::string& message, const std::string& colour) {
 		std::cout << colour << message << "\033[0m" << std::endl;
+
+		std::fstream file(this->log_file, std::ios::out | std::ios::app);
+		if (file.is_open()) {
+			file.write(message.c_str(), message.size());
+			file.write("\n", 1);
+			file.close();
+		}
+		else {
+			GRAPE_LOG_ERROR("Unable to open log file '{}' for writing.", this->log_file);
+		}
 	}
 };

--- a/engine/source/logger.cpp
+++ b/engine/source/logger.cpp
@@ -4,10 +4,16 @@
 #include <fstream>
 
 namespace GRAPE {
-	Logger::Logger(const std::string& log_name) {
-		this->log_file = log_name;
-		
-		// Reset log file
+	Logger& Logger::GetLogger() {
+		static Logger self;
+		return self;
+	}
+
+	void Logger::SetLogFile(const std::string& filepath) {
+		this->log_file = filepath;
+	}
+
+	void Logger::ClearLogFile() {
 		std::fstream file(this->log_file, std::ios::out | std::ios::trunc);
 		if (file.is_open()) {
 			file.close();

--- a/engine/source/logger.cpp
+++ b/engine/source/logger.cpp
@@ -3,8 +3,8 @@
 #include <iostream>
 
 namespace GRAPE {
-	Logger::Logger() {
-
+	Logger::Logger(const std::string& log_name) {
+		(log_name);
 	}
 
 	void Logger::LogMessage(const std::string& message, const std::string& colour) {

--- a/engine/source/logger.cpp
+++ b/engine/source/logger.cpp
@@ -1,0 +1,13 @@
+#include "logger.hpp"
+
+#include <iostream>
+
+namespace GRAPE {
+	Logger::Logger() {
+
+	}
+
+	void Logger::LogMessage(const std::string& message) {
+		std::cout << message << std::endl;
+	}
+};

--- a/engine/source/logger.cpp
+++ b/engine/source/logger.cpp
@@ -14,17 +14,30 @@ namespace GRAPE {
 		}
 	}
 
-	void Logger::LogMessage(const std::string& message, const std::string& colour) {
-		std::cout << colour << message << "\033[0m" << std::endl;
+	void Logger::LogMessage(const std::string& message, LogLevel level) {
+		const std::string log_colours[7] = {
+			"\033[0m",		// NONE
+			"\033[97;41m",	// FATAL
+			"\033[91m",		// ERROR
+			"\033[93m",		// WARN
+			"\033[94m",		// INFO
+			"\033[92m",		// DEBUG
+			"\033[37m"		// TRACE
+		};
 
-		std::fstream file(this->log_file, std::ios::out | std::ios::app);
-		if (file.is_open()) {
-			file.write(message.c_str(), message.size());
-			file.write("\n", 1);
-			file.close();
-		}
-		else {
-			GRAPE_LOG_ERROR("Unable to open log file '{}' for writing.", this->log_file);
+		std::cout << log_colours[level] << message << "\033[0m" << std::endl;
+
+		// We don't write logs with a level of NONE to a file.
+		if (level != LogLevel::NONE) {
+			std::fstream file(this->log_file, std::ios::out | std::ios::app);
+			if (file.is_open()) {
+				file.write(message.c_str(), message.size());
+				file.write("\n", 1);
+				file.close();
+			}
+			else {
+				GRAPE_LOG_ERROR("Unable to open log file '{}' for writing.", this->log_file);
+			}
 		}
 	}
 };

--- a/engine/source/logger.cpp
+++ b/engine/source/logger.cpp
@@ -7,7 +7,7 @@ namespace GRAPE {
 
 	}
 
-	void Logger::LogMessage(const std::string& message) {
-		std::cout << message << std::endl;
+	void Logger::LogMessage(const std::string& message, const std::string& colour) {
+		std::cout << colour << message << "\033[0m" << std::endl;
 	}
 };

--- a/engine/source/logger.cpp
+++ b/engine/source/logger.cpp
@@ -36,7 +36,7 @@ namespace GRAPE {
 				file.close();
 			}
 			else {
-				GRAPE_LOG_ERROR("Unable to open log file '{}' for writing.", this->log_file);
+				this->LogMessage("Unable to write to log file.", LogLevel::NONE);
 			}
 		}
 	}

--- a/engine/source/logger.hpp
+++ b/engine/source/logger.hpp
@@ -4,100 +4,77 @@
 #include <string>
 #include <format>
 
-#define GRAPE_LOG_FATAL(format, ...) GRAPE::Logger::GetLogger().Fatal(format, __VA_ARGS__);
-#define GRAPE_LOG_ERROR(format, ...) GRAPE::Logger::GetLogger().Error(format, __VA_ARGS__);
-#define GRAPE_LOG_WARN(format, ...) GRAPE::Logger::GetLogger().Warn(format, __VA_ARGS__);
-#define GRAPE_LOG_INFO(format, ...) GRAPE::Logger::GetLogger().Info(format, __VA_ARGS__);
-#define GRAPE_LOG_TRACE(format, ...) GRAPE::Logger::GetLogger().Trace(format, __VA_ARGS__);
+namespace GRAPE {
+	namespace Logger {
+		enum LogLevel {
+			FATAL = 0,
+			ERROR = 1,
+			WARN = 2,
+			INFO = 3,
+			DEBUG = 4,
+			TRACE = 5
+		};
+
+		class Logger {
+		private:
+
+			std::string log_file = "game-log.txt";
+		public:
+			Logger() = default;
+
+			void LogMessage(const std::string& message, LogLevel level);
+
+			static Logger& GetLogger();
+
+			void SetLogFile(const std::string& filepath);
+			void ClearLogFile();
+		};
+	};
+}
+
+#define GRAPE_LOG_FATAL(fmt_str, ...) \
+	GRAPE::Logger::Logger::GetLogger().LogMessage( \
+		std::format(fmt_str, __VA_ARGS__), \
+		GRAPE::Logger::LogLevel::FATAL \
+	)
+
+#define GRAPE_LOG_ERROR(fmt_str, ...) \
+	GRAPE::Logger::Logger::GetLogger().LogMessage( \
+		std::format(fmt_str, __VA_ARGS__), \
+		GRAPE::Logger::LogLevel::ERROR \
+	)
+
+#define GRAPE_LOG_WARN(fmt_str, ...) \
+	GRAPE::Logger::Logger::GetLogger().LogMessage( \
+		std::format(fmt_str, __VA_ARGS__), \
+		GRAPE::Logger::LogLevel::WARN \
+	)
+
+#define GRAPE_LOG_INFO(fmt_str, ...) \
+	GRAPE::Logger::Logger::GetLogger().LogMessage( \
+		std::format(fmt_str, __VA_ARGS__), \
+		GRAPE::Logger::LogLevel::INFO \
+	)
+
+#define GRAPE_LOG_DEBUG(fmt_str, ...) \
+	GRAPE::Logger::Logger::GetLogger().LogMessage( \
+		std::format(fmt_str, __VA_ARGS__), \
+		GRAPE::Logger::LogLevel::DEBUG \
+	)
+
+#define GRAPE_LOG_TRACE(fmt_str, ...) \
+	GRAPE::Logger::Logger::GetLogger().LogMessage( \
+		std::format(fmt_str, __VA_ARGS__), \
+		GRAPE::Logger::LogLevel::TRACE \
+	)
 
 #define GRAPE_ASSERT(value, format, ...) \
 	if (!(value)) { \
-		GRAPE::Logger::GetLogger().Fatal(format, __VA_ARGS__); \
+		GRAPE::Logger::Logger::GetLogger().LogMessage( \
+			std::format(fmt_str, __VA_ARGS__), \
+			GRAPE::Logger::LogLevel::TRACE \
+		); \
 		exit(-1); \
 	}
-
-#if defined(GRAPE_DEBUG)
-	#define GRAPE_LOG_DEBUG(format, ...) GRAPE::Logger::GetLogger().Debug(format, __VA_ARGS__);
-	#define GRAPE_LOG_TRACE(format, ...) GRAPE::Logger::GetLogger().Trace(format, __VA_ARGS__);
-#else defined(GRAPE_RELEASE)
-	#define GRAPE_LOG_DEBUG(format, ...)
-	#define GRAPE_LOG_TRACE(format, ...)
-#endif
-
-namespace GRAPE {
-	enum LogLevel {
-		NONE = 0,
-		FATAL = 1,
-		ERROR = 2,
-		WARN = 3,
-		INFO = 4,
-		DEBUG = 5,
-		TRACE = 6
-	};
-
-	class Logger {
-	private:
-		void LogMessage(const std::string& message, LogLevel level);
-
-		std::string log_file = "game-log.txt";
-	public:
-		Logger() = default;
-
-		static Logger& GetLogger();
-
-		void SetLogFile(const std::string& filepath);
-		void ClearLogFile();
-
-		template <typename... ArgTypes>
-		void Fatal(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
-			this->LogMessage(
-				std::format("[FATAL]: {}", std::format(format, std::forward<ArgTypes>(args)...)),
-				LogLevel::FATAL
-			);
-		}
-
-		template <typename... ArgTypes>
-		void Error(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
-			this->LogMessage(
-				std::format("[ERROR]: {}", std::format(format, std::forward<ArgTypes>(args)...)),
-				LogLevel::ERROR
-			);
-		}
-
-		template <typename... ArgTypes>
-		void Warn(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
-			this->LogMessage(
-				std::format("[WARN]: {}", std::format(format, std::forward<ArgTypes>(args)...)),
-				LogLevel::WARN
-			);
-		}
-
-		template <typename... ArgTypes>
-		void Info(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
-			this->LogMessage(
-				std::format("[INFO]: {}", std::format(format, std::forward<ArgTypes>(args)...)),
-				LogLevel::INFO
-			);
-		}
-
-		#if defined(GRAPE_DEBUG)
-			template <typename... ArgTypes>
-			void Debug(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
-				this->LogMessage(
-					std::format("[DEBUG]: {}", std::format(format, std::forward<ArgTypes>(args)...)),
-					LogLevel::DEBUG
-				);
-			}
-
-			template <typename... ArgTypes>
-			void Trace(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
-				this->LogMessage(
-					std::format("[TRACE]: {}", std::format(format, std::forward<ArgTypes>(args)...)),
-					LogLevel::TRACE
-				);
-			}
-		#endif
-	};
-}
 
 #endif

--- a/engine/source/logger.hpp
+++ b/engine/source/logger.hpp
@@ -47,7 +47,7 @@ namespace GRAPE {
 		void Error(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
 			std::stringstream stream;
 			stream << "[ERROR]: " << std::format(format, std::forward<ArgTypes>(args)...);
-			this->LogMessage(stream.str(), "\033[31m");
+			this->LogMessage(stream.str(), "\033[91m");
 		}
 
 		template <typename... ArgTypes>

--- a/engine/source/logger.hpp
+++ b/engine/source/logger.hpp
@@ -12,7 +12,7 @@
 #define GRAPE_LOG_TRACE(format, ...) GRAPE::Logger::GetLogger().Trace(format, __VA_ARGS__);
 
 #define GRAPE_ASSERT(value, format, ...) \
-	if (value) { GRAPE::Logger::GetLogger().Fatal(format, __VA_ARGS__); }
+	if (!(value)) { GRAPE::Logger::GetLogger().Fatal(format, __VA_ARGS__); }
 
 #if defined(GRAPE_DEBUG)
 	#define GRAPE_LOG_DEBUG(format, ...) GRAPE::Logger::GetLogger().Debug(format, __VA_ARGS__);

--- a/engine/source/logger.hpp
+++ b/engine/source/logger.hpp
@@ -10,7 +10,17 @@
 #define GRAPE_LOG_WARN(format, ...) GRAPE::Logger::GetLogger().Warn(format, __VA_ARGS__);
 #define GRAPE_LOG_INFO(format, ...) GRAPE::Logger::GetLogger().Info(format, __VA_ARGS__);
 #define GRAPE_LOG_TRACE(format, ...) GRAPE::Logger::GetLogger().Trace(format, __VA_ARGS__);
-#define GRAPE_LOG_DEBUG(format, ...) GRAPE::Logger::GetLogger().Debug(format, __VA_ARGS__);
+
+#define GRAPE_ASSERT(value, format, ...) \
+	if (value) { GRAPE::Logger::GetLogger().Fatal(format, __VA_ARGS__); }
+
+#if defined(GRAPE_DEBUG)
+	#define GRAPE_LOG_DEBUG(format, ...) GRAPE::Logger::GetLogger().Debug(format, __VA_ARGS__);
+	#define GRAPE_LOG_TRACE(format, ...) GRAPE::Logger::GetLogger().Trace(format, __VA_ARGS__);
+#else defined(GRAPE_RELEASE)
+	#define GRAPE_LOG_DEBUG(format, ...)
+	#define GRAPE_LOG_TRACE(format, ...)
+#endif
 
 namespace GRAPE {
 	class Logger {
@@ -54,24 +64,19 @@ namespace GRAPE {
 			this->LogMessage(stream.str(), "\033[36m");
 		}
 
-		template <typename... ArgTypes>
-		void Trace(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
-			std::stringstream stream;
-			stream << "[TRACE]: " << std::format(format, std::forward<ArgTypes>(args)...);
-			this->LogMessage(stream.str(), "\033[37m");
-		}
-
-		#ifdef GRAPE_DEBUG
+		#if defined(GRAPE_DEBUG)
 			template <typename... ArgTypes>
 			void Debug(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
 				std::stringstream stream;
 				stream << "[DEBUG]: " << std::format(format, std::forward<ArgTypes>(args)...);
 				this->LogMessage(stream.str(), "\033[92m");
 			}
-		#else
+
 			template <typename... ArgTypes>
-			void Debug(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
-				(format = format); // bye bye error
+			void Trace(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
+				std::stringstream stream;
+				stream << "[TRACE]: " << std::format(format, std::forward<ArgTypes>(args)...);
+				this->LogMessage(stream.str(), "\033[37m");
 			}
 		#endif
 	};

--- a/engine/source/logger.hpp
+++ b/engine/source/logger.hpp
@@ -1,7 +1,6 @@
 #ifndef HPP_GRAPEENGINE_LOGGER
 #define HPP_GRAPEENGINE_LOGGER
 
-#include <iostream>
 #include <sstream>
 #include <string>
 #include <format>
@@ -19,6 +18,8 @@ namespace GRAPE {
 		Logger(const std::string& log_name);
 
 		void LogMessage(const std::string& message, const std::string& colour);
+
+		std::string log_file;
 	public:
 		inline static Logger& GetLogger() noexcept {
 			static Logger self("game-log.txt");

--- a/engine/source/logger.hpp
+++ b/engine/source/logger.hpp
@@ -22,7 +22,7 @@ namespace GRAPE {
 		void Fatal(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
 			std::stringstream stream;
 			stream << "[FATAL]: " << std::format(format, std::forward<ArgTypes>(args)...);
-			this->LogMessage(stream.str(), "\033[37;41m");
+			this->LogMessage(stream.str(), "\033[97;41m");
 		}
 
 		template <typename... ArgTypes>
@@ -45,6 +45,27 @@ namespace GRAPE {
 			stream << "[INFO]: " << std::format(format, std::forward<ArgTypes>(args)...);
 			this->LogMessage(stream.str(), "\033[36m");
 		}
+
+		template <typename... ArgTypes>
+		void Trace(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
+			std::stringstream stream;
+			stream << "[TRACE]: " << std::format(format, std::forward<ArgTypes>(args)...);
+			this->LogMessage(stream.str(), "\033[37m");
+		}
+
+		#ifdef GRAPE_DEBUG
+			template <typename... ArgTypes>
+			void Debug(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
+				std::stringstream stream;
+				stream << "[DEBUG]: " << std::format(format, std::forward<ArgTypes>(args)...);
+				this->LogMessage(stream.str(), "\033[92m");
+			}
+		#else
+			template <typename... ArgTypes>
+			void Debug(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
+
+			}
+		#endif
 	};
 }
 

--- a/engine/source/logger.hpp
+++ b/engine/source/logger.hpp
@@ -11,7 +11,10 @@
 #define GRAPE_LOG_TRACE(format, ...) GRAPE::Logger::GetLogger().Trace(format, __VA_ARGS__);
 
 #define GRAPE_ASSERT(value, format, ...) \
-	if (!(value)) { GRAPE::Logger::GetLogger().Fatal(format, __VA_ARGS__); }
+	if (!(value)) { \
+		GRAPE::Logger::GetLogger().Fatal(format, __VA_ARGS__); \
+		exit(-1); \
+	}
 
 #if defined(GRAPE_DEBUG)
 	#define GRAPE_LOG_DEBUG(format, ...) GRAPE::Logger::GetLogger().Debug(format, __VA_ARGS__);

--- a/engine/source/logger.hpp
+++ b/engine/source/logger.hpp
@@ -6,15 +6,22 @@
 #include <string>
 #include <format>
 
+#define GRAPE_LOG_FATAL(format, ...) GRAPE::Logger::GetLogger().Fatal(format, __VA_ARGS__);
+#define GRAPE_LOG_ERROR(format, ...) GRAPE::Logger::GetLogger().Error(format, __VA_ARGS__);
+#define GRAPE_LOG_WARN(format, ...) GRAPE::Logger::GetLogger().Warn(format, __VA_ARGS__);
+#define GRAPE_LOG_INFO(format, ...) GRAPE::Logger::GetLogger().Info(format, __VA_ARGS__);
+#define GRAPE_LOG_TRACE(format, ...) GRAPE::Logger::GetLogger().Trace(format, __VA_ARGS__);
+#define GRAPE_LOG_DEBUG(format, ...) GRAPE::Logger::GetLogger().Debug(format, __VA_ARGS__);
+
 namespace GRAPE {
 	class Logger {
 	private:
-		Logger();
+		Logger(const std::string& log_name);
 
 		void LogMessage(const std::string& message, const std::string& colour);
 	public:
-		inline static Logger& GetLogger() {
-			static Logger self{};
+		inline static Logger& GetLogger() noexcept {
+			static Logger self("game-log.txt");
 			return self;
 		}
 

--- a/engine/source/logger.hpp
+++ b/engine/source/logger.hpp
@@ -35,16 +35,16 @@ namespace GRAPE {
 
 	class Logger {
 	private:
-		Logger(const std::string& log_name);
-
 		void LogMessage(const std::string& message, LogLevel level);
 
-		std::string log_file;
+		std::string log_file = "game-log.txt";
 	public:
-		inline static Logger& GetLogger() noexcept {
-			static Logger self("game-log.txt");
-			return self;
-		}
+		Logger() = default;
+
+		static Logger& GetLogger();
+
+		void SetLogFile(const std::string& filepath);
+		void ClearLogFile();
 
 		template <typename... ArgTypes>
 		void Fatal(std::format_string<ArgTypes...> format, ArgTypes&&... args) {

--- a/engine/source/logger.hpp
+++ b/engine/source/logger.hpp
@@ -23,11 +23,21 @@
 #endif
 
 namespace GRAPE {
+	enum LogLevel {
+		NONE = 0,
+		FATAL = 1,
+		ERROR = 2,
+		WARN = 3,
+		INFO = 4,
+		DEBUG = 5,
+		TRACE = 6
+	};
+
 	class Logger {
 	private:
 		Logger(const std::string& log_name);
 
-		void LogMessage(const std::string& message, const std::string& colour);
+		void LogMessage(const std::string& message, LogLevel level);
 
 		std::string log_file;
 	public:
@@ -40,28 +50,28 @@ namespace GRAPE {
 		void Fatal(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
 			std::stringstream stream;
 			stream << "[FATAL]: " << std::format(format, std::forward<ArgTypes>(args)...);
-			this->LogMessage(stream.str(), "\033[97;41m");
+			this->LogMessage(stream.str(), LogLevel::FATAL);
 		}
 
 		template <typename... ArgTypes>
 		void Error(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
 			std::stringstream stream;
 			stream << "[ERROR]: " << std::format(format, std::forward<ArgTypes>(args)...);
-			this->LogMessage(stream.str(), "\033[91m");
+			this->LogMessage(stream.str(), LogLevel::ERROR);
 		}
 
 		template <typename... ArgTypes>
 		void Warn(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
 			std::stringstream stream;
 			stream << "[WARN]: " << std::format(format, std::forward<ArgTypes>(args)...);
-			this->LogMessage(stream.str(), "\033[33m");
+			this->LogMessage(stream.str(), LogLevel::WARN);
 		}
 
 		template <typename... ArgTypes>
 		void Info(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
 			std::stringstream stream;
 			stream << "[INFO]: " << std::format(format, std::forward<ArgTypes>(args)...);
-			this->LogMessage(stream.str(), "\033[36m");
+			this->LogMessage(stream.str(), LogLevel::INFO);
 		}
 
 		#if defined(GRAPE_DEBUG)
@@ -69,14 +79,14 @@ namespace GRAPE {
 			void Debug(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
 				std::stringstream stream;
 				stream << "[DEBUG]: " << std::format(format, std::forward<ArgTypes>(args)...);
-				this->LogMessage(stream.str(), "\033[92m");
+				this->LogMessage(stream.str(), LogLevel::DEBUG);
 			}
 
 			template <typename... ArgTypes>
 			void Trace(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
 				std::stringstream stream;
 				stream << "[TRACE]: " << std::format(format, std::forward<ArgTypes>(args)...);
-				this->LogMessage(stream.str(), "\033[37m");
+				this->LogMessage(stream.str(), LogLevel::TRACE);
 			}
 		#endif
 	};

--- a/engine/source/logger.hpp
+++ b/engine/source/logger.hpp
@@ -11,7 +11,7 @@ namespace GRAPE {
 	private:
 		Logger();
 
-		void LogMessage(const std::string& message);
+		void LogMessage(const std::string& message, const std::string& colour);
 	public:
 		inline static Logger& GetLogger() {
 			static Logger self{};
@@ -22,28 +22,28 @@ namespace GRAPE {
 		void Fatal(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
 			std::stringstream stream;
 			stream << "[FATAL]: " << std::format(format, std::forward<ArgTypes>(args)...);
-			this->LogMessage(stream.str());
+			this->LogMessage(stream.str(), "\033[37;41m");
 		}
 
 		template <typename... ArgTypes>
 		void Error(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
 			std::stringstream stream;
 			stream << "[ERROR]: " << std::format(format, std::forward<ArgTypes>(args)...);
-			this->LogMessage(stream.str());
+			this->LogMessage(stream.str(), "\033[31m");
 		}
 
 		template <typename... ArgTypes>
 		void Warn(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
 			std::stringstream stream;
 			stream << "[WARN]: " << std::format(format, std::forward<ArgTypes>(args)...);
-			this->LogMessage(stream.str());
+			this->LogMessage(stream.str(), "\033[33m");
 		}
 
 		template <typename... ArgTypes>
 		void Info(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
 			std::stringstream stream;
 			stream << "[INFO]: " << std::format(format, std::forward<ArgTypes>(args)...);
-			this->LogMessage(stream.str());
+			this->LogMessage(stream.str(), "\033[36m");
 		}
 	};
 }

--- a/engine/source/logger.hpp
+++ b/engine/source/logger.hpp
@@ -1,0 +1,51 @@
+#ifndef HPP_GRAPEENGINE_LOGGER
+#define HPP_GRAPEENGINE_LOGGER
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <format>
+
+namespace GRAPE {
+	class Logger {
+	private:
+		Logger();
+
+		void LogMessage(const std::string& message);
+	public:
+		inline static Logger& GetLogger() {
+			static Logger self{};
+			return self;
+		}
+
+		template <typename... ArgTypes>
+		void Fatal(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
+			std::stringstream stream;
+			stream << "[FATAL]: " << std::format(format, std::forward<ArgTypes>(args)...);
+			this->LogMessage(stream.str());
+		}
+
+		template <typename... ArgTypes>
+		void Error(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
+			std::stringstream stream;
+			stream << "[ERROR]: " << std::format(format, std::forward<ArgTypes>(args)...);
+			this->LogMessage(stream.str());
+		}
+
+		template <typename... ArgTypes>
+		void Warn(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
+			std::stringstream stream;
+			stream << "[WARN]: " << std::format(format, std::forward<ArgTypes>(args)...);
+			this->LogMessage(stream.str());
+		}
+
+		template <typename... ArgTypes>
+		void Info(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
+			std::stringstream stream;
+			stream << "[INFO]: " << std::format(format, std::forward<ArgTypes>(args)...);
+			this->LogMessage(stream.str());
+		}
+	};
+}
+
+#endif

--- a/engine/source/logger.hpp
+++ b/engine/source/logger.hpp
@@ -63,7 +63,7 @@ namespace GRAPE {
 		#else
 			template <typename... ArgTypes>
 			void Debug(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
-
+				(format = format); // bye bye error
 			}
 		#endif
 	};

--- a/engine/source/logger.hpp
+++ b/engine/source/logger.hpp
@@ -1,7 +1,6 @@
 #ifndef HPP_GRAPEENGINE_LOGGER
 #define HPP_GRAPEENGINE_LOGGER
 
-#include <sstream>
 #include <string>
 #include <format>
 
@@ -48,45 +47,51 @@ namespace GRAPE {
 
 		template <typename... ArgTypes>
 		void Fatal(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
-			std::stringstream stream;
-			stream << "[FATAL]: " << std::format(format, std::forward<ArgTypes>(args)...);
-			this->LogMessage(stream.str(), LogLevel::FATAL);
+			this->LogMessage(
+				std::format("[FATAL]: {}", std::format(format, std::forward<ArgTypes>(args)...)),
+				LogLevel::FATAL
+			);
 		}
 
 		template <typename... ArgTypes>
 		void Error(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
-			std::stringstream stream;
-			stream << "[ERROR]: " << std::format(format, std::forward<ArgTypes>(args)...);
-			this->LogMessage(stream.str(), LogLevel::ERROR);
+			this->LogMessage(
+				std::format("[ERROR]: {}", std::format(format, std::forward<ArgTypes>(args)...)),
+				LogLevel::ERROR
+			);
 		}
 
 		template <typename... ArgTypes>
 		void Warn(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
-			std::stringstream stream;
-			stream << "[WARN]: " << std::format(format, std::forward<ArgTypes>(args)...);
-			this->LogMessage(stream.str(), LogLevel::WARN);
+			this->LogMessage(
+				std::format("[WARN]: {}", std::format(format, std::forward<ArgTypes>(args)...)),
+				LogLevel::WARN
+			);
 		}
 
 		template <typename... ArgTypes>
 		void Info(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
-			std::stringstream stream;
-			stream << "[INFO]: " << std::format(format, std::forward<ArgTypes>(args)...);
-			this->LogMessage(stream.str(), LogLevel::INFO);
+			this->LogMessage(
+				std::format("[INFO]: {}", std::format(format, std::forward<ArgTypes>(args)...)),
+				LogLevel::INFO
+			);
 		}
 
 		#if defined(GRAPE_DEBUG)
 			template <typename... ArgTypes>
 			void Debug(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
-				std::stringstream stream;
-				stream << "[DEBUG]: " << std::format(format, std::forward<ArgTypes>(args)...);
-				this->LogMessage(stream.str(), LogLevel::DEBUG);
+				this->LogMessage(
+					std::format("[DEBUG]: {}", std::format(format, std::forward<ArgTypes>(args)...)),
+					LogLevel::DEBUG
+				);
 			}
 
 			template <typename... ArgTypes>
 			void Trace(std::format_string<ArgTypes...> format, ArgTypes&&... args) {
-				std::stringstream stream;
-				stream << "[TRACE]: " << std::format(format, std::forward<ArgTypes>(args)...);
-				this->LogMessage(stream.str(), LogLevel::TRACE);
+				this->LogMessage(
+					std::format("[TRACE]: {}", std::format(format, std::forward<ArgTypes>(args)...)),
+					LogLevel::TRACE
+				);
 			}
 		#endif
 	};

--- a/engine/source/system/window.cpp
+++ b/engine/source/system/window.cpp
@@ -1,11 +1,15 @@
 #include "window.hpp"
 
-#include <iostream>
+#include "logger.hpp"
 
 namespace System {
 	Window::Window(const std::string& title, u32 width, u32 height, bool fullscreen) {
 		if (!glfwInit()) {
-			// log something
+			GRAPE_LOG_FATAL(
+				"GLFW Backend: Failed to init - {}.",
+				glfwGetError(nullptr)
+			);
+
 			return;
 		}
 
@@ -28,7 +32,11 @@ namespace System {
 		}
 
 		if (this->pWindow == nullptr) {
-			// log something. critical error.
+			GRAPE_LOG_FATAL(
+				"GLFW Backend: Failed to open a window - {}.",
+				glfwGetError(nullptr)
+			);
+
 			return;
 		}
 	}

--- a/engine/source/system/window.hpp
+++ b/engine/source/system/window.hpp
@@ -1,9 +1,11 @@
 #ifndef HPP_GRAPEENGINE_WINDOW
 #define HPP_GRAPEENGINE_WINDOW
 
-#include "core.hpp"
+#include <string>
 
 #include <GLFW/glfw3.h>
+
+#include "core.hpp"
 
 namespace System {
 	class Window {

--- a/sandbox/source/main.cpp
+++ b/sandbox/source/main.cpp
@@ -10,12 +10,12 @@ public:
 		
 		this->InitWindow(false);
 
-		GRAPE::Logger::GetLogger().Fatal("Testing");
-		GRAPE::Logger::GetLogger().Error("Testing");
-		GRAPE::Logger::GetLogger().Warn("Testing");
-		GRAPE::Logger::GetLogger().Info("Testing");
-		GRAPE::Logger::GetLogger().Trace("Testing");
-		GRAPE::Logger::GetLogger().Debug("Testing");
+		GRAPE_LOG_FATAL("Testing");
+		GRAPE_LOG_ERROR("Testing");
+		GRAPE_LOG_WARN("Testing");
+		GRAPE_LOG_INFO("Testing");
+		GRAPE_LOG_TRACE("Testing");
+		GRAPE_LOG_DEBUG("Testing");
 	}
 
 	void Exit() override {

--- a/sandbox/source/main.cpp
+++ b/sandbox/source/main.cpp
@@ -1,6 +1,6 @@
 #include "core.hpp"
-
 #include "application.hpp"
+#include "logger.hpp"
 
 class Sandbox : public GRAPE::Application {
 public:
@@ -9,6 +9,8 @@ public:
 		this->SetAppSize(800, 600);
 		
 		this->InitWindow(false);
+
+		GRAPE::Logger::GetLogger().Fatal("Sandbox: {}", "Hello, World!");
 	}
 
 	void Exit() override {

--- a/sandbox/source/main.cpp
+++ b/sandbox/source/main.cpp
@@ -14,8 +14,11 @@ public:
 		GRAPE_LOG_ERROR("Testing");
 		GRAPE_LOG_WARN("Testing");
 		GRAPE_LOG_INFO("Testing");
-		GRAPE_LOG_TRACE("Testing");
 		GRAPE_LOG_DEBUG("Testing");
+		GRAPE_LOG_TRACE("Testing");
+
+		bool assert_test = false;
+		GRAPE_ASSERT(assert_test != true, "'assert_test == true' failed.");
 	}
 
 	void Exit() override {

--- a/sandbox/source/main.cpp
+++ b/sandbox/source/main.cpp
@@ -18,7 +18,7 @@ public:
 		GRAPE_LOG_TRACE("Testing");
 
 		bool assert_test = false;
-		GRAPE_ASSERT(assert_test != true, "'assert_test == true' failed.");
+		GRAPE_ASSERT(assert_test == true, "'assert_test == true' failed.");
 	}
 
 	void Exit() override {

--- a/sandbox/source/main.cpp
+++ b/sandbox/source/main.cpp
@@ -14,6 +14,8 @@ public:
 		GRAPE::Logger::GetLogger().Error("Testing");
 		GRAPE::Logger::GetLogger().Warn("Testing");
 		GRAPE::Logger::GetLogger().Info("Testing");
+		GRAPE::Logger::GetLogger().Trace("Testing");
+		GRAPE::Logger::GetLogger().Debug("Testing");
 	}
 
 	void Exit() override {

--- a/sandbox/source/main.cpp
+++ b/sandbox/source/main.cpp
@@ -29,8 +29,8 @@ public:
 
 int main() {
 	// This needs to be done first.
-	GRAPE::Logger::GetLogger().SetLogFile("test-log.txt");
-	GRAPE::Logger::GetLogger().ClearLogFile();
+	GRAPE::Logger::Logger::GetLogger().SetLogFile("test-log.txt");
+	GRAPE::Logger::Logger::GetLogger().ClearLogFile();
 
 	Sandbox sandbox;
 	sandbox.Init();

--- a/sandbox/source/main.cpp
+++ b/sandbox/source/main.cpp
@@ -27,6 +27,10 @@ public:
 };
 
 int main() {
+	// This needs to be done first.
+	GRAPE::Logger::GetLogger().SetLogFile("test-log.txt");
+	GRAPE::Logger::GetLogger().ClearLogFile();
+
 	Sandbox sandbox;
 	sandbox.Init();
 	sandbox.Run();

--- a/sandbox/source/main.cpp
+++ b/sandbox/source/main.cpp
@@ -17,8 +17,9 @@ public:
 		GRAPE_LOG_DEBUG("Testing");
 		GRAPE_LOG_TRACE("Testing");
 
-		bool assert_test = false;
-		GRAPE_ASSERT(assert_test == true, "'assert_test == true' failed.");
+		// Asserts kill the process.
+		// bool assert_test = false;
+		// GRAPE_ASSERT(assert_test == true, "'assert_test == true' failed.");
 	}
 
 	void Exit() override {

--- a/sandbox/source/main.cpp
+++ b/sandbox/source/main.cpp
@@ -10,7 +10,10 @@ public:
 		
 		this->InitWindow(false);
 
-		GRAPE::Logger::GetLogger().Fatal("Sandbox: {}", "Hello, World!");
+		GRAPE::Logger::GetLogger().Fatal("Testing");
+		GRAPE::Logger::GetLogger().Error("Testing");
+		GRAPE::Logger::GetLogger().Warn("Testing");
+		GRAPE::Logger::GetLogger().Info("Testing");
 	}
 
 	void Exit() override {


### PR DESCRIPTION
This PR implements a logger.

To-Do:
- [X] Log messages to the terminal.
- [X] A different colour for each log level.
- [X] Debug and trace messages when built in debug mode.
- [X] Macros for easier use of logger.
- [X] Logging to a file.
- [x] Asserts.

Notes:
- The filename of the log is ``game-log.txt``.
- Asserts are logged as fatal errors.
- Debug and trace only work in debug builds.
- Later down the line this will need to run on a separate thread.